### PR TITLE
Removing browser detection.

### DIFF
--- a/jquery.ipaddress.js
+++ b/jquery.ipaddress.js
@@ -24,8 +24,9 @@
 				if (options.cidr) {
 					octet_html += '/<input type="text" class="ip_cidr ip_octet" id="' + id_prefix + '_octet_cidr" maxlength="2" value="' + ip_cidr + '" />';
 				}
-
-				$this.after($('<div class="ip_container" style="display: inline-block;"/>').html(octet_html));
+				
+				var ipContainerStyle = 'display: inline-block; zoom: 1; *display: inline;';
+				$this.after($('<div class="ip_container" style="' + ipContainerStyle + '"/>').html(octet_html));
 				$this.addClass('ip-enabled');
 			}
 

--- a/jquery.ipaddress.js
+++ b/jquery.ipaddress.js
@@ -25,7 +25,7 @@
 					octet_html += '/<input type="text" class="ip_cidr ip_octet" id="' + id_prefix + '_octet_cidr" maxlength="2" value="' + ip_cidr + '" />';
 				}
 
-				$this.after($('<div class="ip_container" style="display: inline' + (($.browser && $.browser.msie) ? '' : '-block') + ';"/>').html(octet_html));
+				$this.after($('<div class="ip_container" style="display: inline-block;"/>').html(octet_html));
 				$this.addClass('ip-enabled');
 			}
 


### PR DESCRIPTION
$.browser property was removed in jQuery 1.9 and is available only through the jQuery.migrate plugin. See http://api.jquery.com/jQuery.browser/.

display:inline-block works perfectly with IE as with other browsers.
